### PR TITLE
Add specific file info to torrent name

### DIFF
--- a/yts_am.py
+++ b/yts_am.py
@@ -39,9 +39,10 @@ class yts_am(object):
     def processJson(self, json):
         movieData = self.getSingleData()
         for movie in json['data']['movies']:
-            movieData['name'] = '{} - {}'.format(movie['title'], movie['year'])
+            basename = '{} - {}'.format(movie['title'], movie['year'])
             movieData['desc_link'] = movie['url']
             for torrent in movie['torrents']:
+                movieData['name'] = basename + ' ({} {})'.format(torrent['quality'], torrent['type'])
                 movieData['seeds'] = torrent['seeds']
                 movieData['leech'] = torrent['peers']
                 movieData['size'] = torrent['size']


### PR DESCRIPTION
Previously, different torrent types (1080p, 720p, 3D, etc) had the same name in the search result list, making them indistinguishable.